### PR TITLE
Added function to sync imported datalayers every hour with a scheduled task

### DIFF
--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -56,6 +56,9 @@ class Admin {
 		add_action( 'manage_owc_ok_location_posts_custom_column', [ 'Openkaarten_Base_Plugin\Admin\Admin', 'location_posts_columns' ], 10, 2 );
 		add_filter( 'manage_owc_ok_location_posts_columns', [ 'Openkaarten_Base_Plugin\Admin\Admin', 'manage_location_posts_columns' ] );
 
+		add_action( 'manage_owc_ok_datalayer_posts_custom_column', [ 'Openkaarten_Base_Plugin\Admin\Admin', 'datalayer_posts_columns' ], 10, 2 );
+		add_filter( 'manage_owc_ok_datalayer_posts_columns', [ 'Openkaarten_Base_Plugin\Admin\Admin', 'manage_datalayer_posts_columns' ] );
+
 		add_action( 'save_post', [ 'Openkaarten_Base_Plugin\Admin\Admin', 'flush_cache_for_specific_endpoints' ], 10, 1 );
 	}
 
@@ -291,7 +294,7 @@ class Admin {
 	 * @return void
 	 */
 	public static function location_posts_columns( $column_key, $post_id ) {
-		// Add location datalayer calue as a column.
+		// Add location datalayer value as a column.
 		if ( 'location_datalayer' === $column_key ) {
 			$datalayer = get_post_meta( $post_id, 'location_datalayer_id', true );
 			if ( $datalayer ) {
@@ -301,6 +304,56 @@ class Admin {
 					esc_url( get_edit_post_link( $datalayer ) ),
 					esc_html( $datalayer_name )
 				);
+			}
+		}
+	}
+
+	/**
+	 * Add custom column to the post list.
+	 *
+	 * @param array $columns The columns.
+	 *
+	 * @return array Modified columns.
+	 */
+	public static function manage_datalayer_posts_columns( $columns ) {
+		// Add datalayer type as a column.
+		$new_columns = [
+			'datalayer_type'        => __( 'Datalayer type', 'openkaarten-base' ),
+			'datalayer_last_import' => __( 'Last import', 'openkaarten-base' ),
+		];
+
+		return array_merge( $columns, $new_columns );
+	}
+
+	/**
+	 * Add custom column to the post list.
+	 *
+	 * @param string $column_key The column key.
+	 * @param int    $post_id    The post ID.
+	 *
+	 * @return void
+	 */
+	public static function datalayer_posts_columns( $column_key, $post_id ) {
+		// Add location datalayer calue as a column.
+		if ( 'datalayer_type' === $column_key ) {
+			$datalayer_type     = get_post_meta( $post_id, 'datalayer_type', true );
+			$datalayer_url_type = get_post_meta( $post_id, 'datalayer_url_type', true );
+			if ( $datalayer_type ) {
+				echo esc_html( $datalayer_type );
+			}
+			if ( 'url' === $datalayer_type && $datalayer_url_type ) {
+				echo ' (' . esc_html( $datalayer_url_type ) . ')';
+			}
+		} elseif ( 'datalayer_last_import' === $column_key ) {
+			$datalayer_url_type = get_post_meta( $post_id, 'datalayer_url_type', true );
+
+			if ( 'live' === $datalayer_url_type ) {
+				return;
+			}
+
+			$datalayer_last_synced = get_post_meta( $post_id, 'datalayer_last_import', true );
+			if ( $datalayer_last_synced ) {
+				echo esc_html( $datalayer_last_synced );
 			}
 		}
 	}

--- a/src/admin/class-cmb2.php
+++ b/src/admin/class-cmb2.php
@@ -167,20 +167,27 @@ class Cmb2 {
 				$location_output = $component->out( 'json' );
 				$location_output = json_decode( $location_output, true );
 
-				$component_properties = $location_output['properties'];
-
 				if ( isset( $location_output['geometry'] ) ) {
 					$geometry = $location_output['geometry'];
 				} else {
 					$geometry = $location_output;
 				}
 
-				$locations[] = [
+				$location = [
 					'feature' => $geometry,
-					'content' => $component_properties['title'] ?: '',
-					'icon'    => $component_properties['marker']['icon'] ?: '',
-					'color'   => $component_properties['marker']['color'] ?: '',
+					'content' => '',
+					'icon'    => '',
+					'color'   => '',
 				];
+
+				if ( ! empty( $location_output['properties'] ) ) {
+					$component_properties = $location_output['properties'];
+					$location['content']  = $component_properties['title'] ?? '';
+					$location['icon']     = $component_properties['marker']['icon'] ?? '';
+					$location['color']    = $component_properties['marker']['color'] ?? '';
+				}
+
+				$locations[] = $location;
 			}
 		} catch ( \Exception $e ) {
 			// Add error message via admin notice.

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -819,7 +819,7 @@ class Datalayers {
 
 				break;
 			case 'url':
-				$file_contents = self::fetch_datalayer_url_data();
+				$file_contents = self::fetch_datalayer_url_data( $object_id );
 
 				break;
 		}
@@ -959,10 +959,18 @@ class Datalayers {
 	/**
 	 * Fetch the data from an external source URL.
 	 *
+	 * @param int $datalayer_id The datalayer ID.
+	 *
 	 * @return mixed
 	 */
-	public static function fetch_datalayer_url_data() {
-		$url      = self::$datalayer_url;
+	public static function fetch_datalayer_url_data( $datalayer_id = false ) {
+		$url = self::$datalayer_url;
+
+		// Get URL when running the cron.
+		if ( defined( 'DOING_CRON' ) && DOING_CRON && $datalayer_id ) {
+			$url = get_post_meta( $datalayer_id, 'datalayer_url', true );
+		}
+
 		$response = wp_remote_get( $url );
 
 		// Check if response is a WP_Error.
@@ -1022,7 +1030,7 @@ class Datalayers {
 
 				break;
 			case 'url':
-				$data = self::fetch_datalayer_url_data();
+				$data = self::fetch_datalayer_url_data( $object_id );
 
 				break;
 		}


### PR DESCRIPTION
@richardkorthuis : Ik heb een scheduled task toegevoegd die ieder uur draait en die van datalayers die het type URL hebben en het URL type import, de locaties opnieuw importeert. Op die manier worden wijzigingen die in de bron gedaan worden, ieder uur gesynchroniseerd naar de OpenKaarten. Ik wil hem eerst mergen naar staging zodat we het zelf kunnen testen op onze staging omgeving, voordat we het live doorzetten.

Aanvullend heb ik wat PHP warnings opgelost en 2 kolommen toegevoegd aan het admin overzicht voor datalayers, waardoor daar het type + URL type en de laatste import datum getoond worden.