### PR TITLE
Feature/live markers and tooltips

### DIFF
--- a/src/admin/class-cmb2.php
+++ b/src/admin/class-cmb2.php
@@ -181,10 +181,29 @@ class Cmb2 {
 				];
 
 				if ( ! empty( $location_output['properties'] ) ) {
-					$component_properties = $location_output['properties'];
-					$location['content']  = $component_properties['title'] ?? '';
-					$location['icon']     = $component_properties['marker']['icon'] ?? '';
-					$location['color']    = $component_properties['marker']['color'] ?? '';
+
+					// Get location properties.
+					$location_properties = $location_output['properties'];
+					if ( 'live' === $datalayer_url_type ) {
+						$location_data_for_marker = $location_output['properties'];
+					} else {
+						$location_data_for_marker = $location_output;
+					}
+
+					// Get marker information.
+					$item_marker = Locations::get_location_marker( $object_id, false, $location_data_for_marker );
+					$geom_marker = [
+						'color' => $item_marker['color'],
+						'icon'  => Locations::get_location_marker_url( $item_marker['icon'] ),
+					];
+
+					// Get title information based on title field mapping.
+					$title_fields = get_post_meta( $object_id, 'title_field_mapping', true );
+					$title = Importer::create_title_from_mapping( $location_properties, $title_fields );
+
+					$location['content'] = $title;
+					$location['icon']    = $geom_marker['icon'] ?? '';
+					$location['color']   = $geom_marker['color'] ?? '';
 				}
 
 				$locations[] = $location;

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -226,7 +226,8 @@ class Datalayers {
 				'name'       => __( 'Datalayer URL', 'openkaarten-base' ),
 				'id'         => 'datalayer_url',
 				'type'       => 'text_url',
-				'desc'       => __( 'Insert a valid URL. The URL must be accessible by the server and the output has to be a supported format: JSON, geoJSON, KML or XML.', 'openkaarten-base' ),
+				'desc'       => __( 'Insert a valid URL. The URL must be accessible by the server and the output has to be a supported format: JSON, geoJSON, KML or XML.', 'openkaarten-base' ) .
+								'<br /><span style="color: red;"><strong>' . __( 'Be aware: updating this field will automatically reset the title field mapping and the field mapping and will remove and re-import all locations for the import URL type datalayers.', 'openkaarten-base' ) . '</strong></span>',
 				'attributes' => [
 					'data-conditional-id'    => 'datalayer_type',
 					'data-conditional-value' => 'url',
@@ -949,12 +950,13 @@ class Datalayers {
 	/**
 	 * Fetch the data from an external source URL.
 	 *
-	 * @param int $datalayer_id The datalayer ID.
+	 * @param int    $datalayer_id The datalayer ID.
+	 * @param string $override_datalayer_url The overridden datalayer URL. This is used when calling the function from the update_post_meta hook for the datalayer URL field.
 	 *
 	 * @return mixed
 	 */
-	public static function fetch_datalayer_url_data( $datalayer_id = false ) {
-		$url = self::$datalayer_url;
+	public static function fetch_datalayer_url_data( $datalayer_id = false, $override_datalayer_url = '' ) {
+		$url = $override_datalayer_url ? : self::$datalayer_url;
 
 		// Get URL when running the cron.
 		if ( defined( 'DOING_CRON' ) && DOING_CRON && $datalayer_id ) {
@@ -988,12 +990,13 @@ class Datalayers {
 	 * Get the source fields from the datalayer URL.
 	 *
 	 * @param int|string $object_id The object ID.
-	 * @param string     $override_datalayer_type The datalayer type.
-	 * @param string     $override_datalayer_url_type The datalayer URL type.
+	 * @param string     $override_datalayer_type The overridden datalayer type. This is used when calling the function from the update_post_meta hook for the datalayer URL field.
+	 * @param string     $override_datalayer_url_type The overridden datalayer URL type. This is used when calling the function from the update_post_meta hook for the datalayer URL field.
+	 * @param string     $override_datalayer_url The overridden datalayer URL. This is used when calling the function from the update_post_meta hook for the datalayer URL field.
 	 *
 	 * @return array|\WP_Error
 	 */
-	public static function get_datalayer_source_fields( $object_id, $override_datalayer_type = false, $override_datalayer_url_type = false ) {
+	public static function get_datalayer_source_fields( $object_id, $override_datalayer_type = false, $override_datalayer_url_type = false, $override_datalayer_url = '' ) {
 		$datalayer_type     = $override_datalayer_type ? : self::$datalayer_type;
 		$datalayer_url_type = $override_datalayer_url_type ? : self::$datalayer_url_type;
 
@@ -1028,7 +1031,7 @@ class Datalayers {
 
 				break;
 			case 'url':
-				$data = self::fetch_datalayer_url_data( $object_id );
+				$data = self::fetch_datalayer_url_data( $object_id, $override_datalayer_url );
 
 				break;
 		}

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -241,7 +241,7 @@ class Datalayers {
 				'name'       => __( 'Datalayer URL type', 'openkaarten-base' ),
 				'id'         => 'datalayer_url_type',
 				'type'       => 'radio_inline',
-				'desc'       => __( 'Select the URL type. Select import to import locations once with the option to synchronize later and select live to retrieve the datalayers from the source directly without importing them.', 'openkaarten-base' ),
+				'desc'       => __( 'Select import to import locations: locations will be synced automatically every hour or manually with the sync button. Select live to retrieve the datalayers from the source directly without importing them.', 'openkaarten-base' ),
 				'options'    => [
 					'import' => __( 'Import', 'openkaarten-base' ),
 					'live'   => __( 'Live', 'openkaarten-base' ),
@@ -743,8 +743,8 @@ class Datalayers {
 			return false;
 		}
 
-		$datalayer_file      = get_post_meta( $cmb->object_id(), 'datalayer_file', true );
-		$datalayer_url       = get_post_meta( $cmb->object_id(), 'datalayer_url', true );
+		$datalayer_file = get_post_meta( $cmb->object_id(), 'datalayer_file', true );
+		$datalayer_url  = get_post_meta( $cmb->object_id(), 'datalayer_url', true );
 
 		return ( ! empty( $datalayer_file ) || ! empty( $datalayer_url ) );
 	}
@@ -993,19 +993,21 @@ class Datalayers {
 	 * @return array|\WP_Error
 	 */
 	public static function get_datalayer_source_fields( $object_id ) {
-		// First try to retrieve the source fields from the postmeta.
-		$source_fields = get_post_meta( $object_id, 'source_fields', true );
+		// First try to retrieve the source fields from the postmeta. But only do this if the datalayer type is not 'live'.
+		if ( 'live' !== self::$datalayer_url_type ) {
+			$source_fields = get_post_meta( $object_id, 'source_fields', true );
 
-		if ( ! empty( $source_fields ) ) {
-			// Get all field labels from the source_fields array.
-			$source_fields = array_map(
-				function ( $field ) {
-					return $field['field_label'];
-				},
-				$source_fields
-			);
+			if ( ! empty( $source_fields ) ) {
+				// Get all field labels from the source_fields array.
+				$source_fields = array_map(
+					function ( $field ) {
+						return $field['field_label'];
+					},
+					$source_fields
+				);
 
-			return $source_fields;
+				return $source_fields;
+			}
 		}
 
 		// If no source fields are set, get the source fields from the datalayer file.

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -702,10 +702,6 @@ class Datalayers {
 			return false;
 		}
 
-		if ( 'live' === self::$datalayer_url_type ) {
-			return false;
-		}
-
 		$datalayer_file = get_post_meta( $cmb->object_id(), 'datalayer_file', true );
 		$datalayer_url  = get_post_meta( $cmb->object_id(), 'datalayer_url', true );
 
@@ -744,10 +740,6 @@ class Datalayers {
 	 */
 	public static function show_markers_metabox( $cmb ) {
 		if ( ! self::is_correct_cmb2_screen() ) {
-			return false;
-		}
-
-		if ( 'live' === self::$datalayer_url_type ) {
 			return false;
 		}
 

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -988,12 +988,17 @@ class Datalayers {
 	 * Get the source fields from the datalayer URL.
 	 *
 	 * @param int|string $object_id The object ID.
+	 * @param string     $override_datalayer_type The datalayer type.
+	 * @param string     $override_datalayer_url_type The datalayer URL type.
 	 *
 	 * @return array|\WP_Error
 	 */
-	public static function get_datalayer_source_fields( $object_id ) {
+	public static function get_datalayer_source_fields( $object_id, $override_datalayer_type = false, $override_datalayer_url_type = false ) {
+		$datalayer_type     = $override_datalayer_type ? : self::$datalayer_type;
+		$datalayer_url_type = $override_datalayer_url_type ? : self::$datalayer_url_type;
+
 		// First try to retrieve the source fields from the postmeta. But only do this if the datalayer type is not 'live'.
-		if ( 'live' !== self::$datalayer_url_type ) {
+		if ( 'live' !== $datalayer_url_type ) {
 			$source_fields = get_post_meta( $object_id, 'source_fields', true );
 
 			if ( ! empty( $source_fields ) ) {
@@ -1010,10 +1015,11 @@ class Datalayers {
 		}
 
 		// If no source fields are set, get the source fields from the datalayer file.
-		switch ( self::$datalayer_type ) {
+		switch ( $datalayer_type ) {
 			case 'fileinput':
 			default:
 				$file = get_attached_file( get_post_meta( $object_id, 'datalayer_file_id', true ) );
+
 				if ( empty( $file ) ) {
 					return [];
 				}

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -745,9 +745,8 @@ class Datalayers {
 
 		$datalayer_file      = get_post_meta( $cmb->object_id(), 'datalayer_file', true );
 		$datalayer_url       = get_post_meta( $cmb->object_id(), 'datalayer_url', true );
-		$title_field_mapping = get_post_meta( $cmb->object_id(), 'title_field_mapping', true );
 
-		return ( ! empty( $datalayer_file ) || ! empty( $datalayer_url ) ) && ! empty( $title_field_mapping );
+		return ( ! empty( $datalayer_file ) || ! empty( $datalayer_url ) );
 	}
 
 	/**

--- a/src/admin/class-datalayers.php
+++ b/src/admin/class-datalayers.php
@@ -230,7 +230,6 @@ class Datalayers {
 				'attributes' => [
 					'data-conditional-id'    => 'datalayer_type',
 					'data-conditional-value' => 'url',
-					'readonly'               => ! empty( self::$datalayer_url ) ? true : false,
 				],
 				'after'      => self::$datalayer_url ? '<p><a href="' . self::$datalayer_url . '" class="button" target="_blank">' . __( 'View source data', 'openkaarten-base' ) . '</a></p>' : '',
 			]

--- a/src/admin/class-importer.php
+++ b/src/admin/class-importer.php
@@ -91,8 +91,18 @@ class Importer {
 	 */
 	public static function update_post_meta( $meta_id, $post_id, $meta_key, $meta_value ) {
 		if ( 'title_field_mapping' === $meta_key ) {
+
 			self::import_geo_file( $post_id, $meta_key, $meta_value );
+
 		} elseif ( 'datalayer_url' === $meta_key ) {
+
+			//phpcs:ignore WordPress.Security.NonceVerification.Missing -- We need to check the POST data.
+			$datalayer_url_type = isset( $_POST['datalayer_url_type'] ) ? sanitize_text_field( wp_unslash( $_POST['datalayer_url_type'] ) ) : null;
+
+			if ( empty( $datalayer_url_type ) ) {
+				return;
+			}
+
 			// Delete title field mapping.
 			delete_post_meta( $post_id, 'title_field_mapping' );
 
@@ -114,12 +124,18 @@ class Importer {
 			if ( isset( $_POST['source_fields'] ) ) {
 				unset( $_POST['source_fields'] );
 			}
-
-			// Force set datalayer_file_id, otherwise source fields can't be retrieved.
-			update_post_meta( $post_id, 'datalayer_file_id', $meta_value );
+			//phpcs:ignore WordPress.Security.NonceVerification.Missing -- We need to unset the POST data.
+			if ( isset( $_POST['title_field_mapping'] ) ) {
+				unset( $_POST['title_field_mapping'] );
+			}
 
 			// Retrieve the property for the title field mapping.
-			$source_fields = Datalayers::get_datalayer_source_fields( $post_id, 'url', 'import' );
+			$source_fields = Datalayers::get_datalayer_source_fields(
+				$post_id,
+				'url',
+				$datalayer_url_type,
+				$meta_value
+			);
 
 			if ( ! empty( $source_fields ) ) {
 				$title_fields = '{' . $source_fields[0] . '}';
@@ -127,11 +143,55 @@ class Importer {
 				$title_fields = '{title}';
 			}
 
-			// Set the title field mapping.
-			update_post_meta( $post_id, 'title_field_mapping', $title_fields );
+			// Don't use update_post_meta but save it directly to the database.
+			// This is because the update_post_meta function will trigger the import and we don't want that here.
+			global $wpdb;
+
+			//phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom query is required here.
+			$wpdb->insert(
+				$wpdb->postmeta,
+				[
+					//phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- We need to insert the meta value.
+					'meta_value' => $title_fields,
+					'post_id'    => $post_id,
+					//phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- We need to insert the meta key.
+					'meta_key'   => 'title_field_mapping',
+				]
+			);
+
+			// Update the field mapping and set all source fields to show.
+			if ( ! empty( $source_fields ) ) {
+				$source_fields_db = [];
+				foreach ( $source_fields as $field ) {
+					add_post_meta( $post_id, 'field_' . $field . '_type', 'text' );
+					add_post_meta( $post_id, 'field_' . $field, $field );
+					add_post_meta( $post_id, 'field_' . $field . '_show', '1' );
+					add_post_meta( $post_id, 'field_' . $field . '_required', '0' );
+					$source_fields_db[] = [
+						'field_label'         => $field,
+						'field_display_label' => $field,
+						'field_type'          => 'text',
+						'field_show'          => 1,
+						'field_required'      => 0,
+					];
+				}
+			}
+
+			// Update the source fields.
+			update_post_meta( $post_id, 'source_fields', $source_fields_db );
 
 			// Import the locations.
-			self::import_locations( $post_id, $title_fields );
+			if ( 'import' === $datalayer_url_type ) {
+				self::import_locations( $post_id, $title_fields );
+			}
+
+			// Redirect to avoid executing other actions.
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- We need to check the POST data.
+			if ( isset( $_POST['_wp_http_referer'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- We need to check the POST data.
+				wp_safe_redirect( sanitize_url( wp_unslash( $_POST['_wp_http_referer'] ) ) );
+				exit;
+			}
 		}
 	}
 

--- a/src/admin/class-locations.php
+++ b/src/admin/class-locations.php
@@ -404,4 +404,54 @@ class Locations {
 			Openkaarten_Base_Functions::save_geometry_object( $post_id, $properties );
 		}
 	}
+
+	/**
+	 * Get the location tooltip.
+	 *
+	 * @param int   $datalayer_id The datalayer ID.
+	 * @param int   $location_id The location ID.
+	 * @param array $location_data The location data.
+	 *
+	 * @return array The tooltip.
+	 */
+	public static function get_location_tooltip( $datalayer_id, $location_id = false, $location_data = false ) {
+		$tooltip = get_post_meta( $datalayer_id, 'tooltip', true );
+
+		if ( ! $tooltip ) {
+			return [];
+		}
+
+		$source_fields      = get_post_meta( $datalayer_id, 'source_fields', true );
+		$datalayer_url_type = get_post_meta( $datalayer_id, 'datalayer_url_type', true ) ? : 'import';
+
+		if ( ! empty( $source_fields ) ) {
+			foreach ( $source_fields as $source_field ) {
+				// Include only fields that are set to show.
+				if ( ! isset( $source_field['field_show'] ) || 'on' !== $source_field['field_show'] ) {
+					continue;
+				}
+
+				if ( 'live' === $datalayer_url_type ) {
+					$location_tooltip_field = $location_data[ $source_field['field_label'] ];
+				} else {
+					$location_tooltip_field = get_post_meta( $location_id, 'field_' . $source_field['field_label'], true );
+				}
+
+				if ( is_array( $location_tooltip_field ) || is_object( $location_tooltip_field ) ) {
+					continue;
+				}
+
+				$search[]  = '{' . $source_field['field_label'] . '}';
+				$replace[] = $location_tooltip_field;
+			}
+		}
+
+		foreach ( $tooltip as &$layout ) {
+			foreach ( $layout as &$field ) {
+				$field = str_replace( $search, $replace, $field );
+			}
+		}
+
+		return $tooltip;
+	}
 }

--- a/src/admin/class-locations.php
+++ b/src/admin/class-locations.php
@@ -432,7 +432,7 @@ class Locations {
 				}
 
 				if ( 'live' === $datalayer_url_type ) {
-					$location_tooltip_field = $location_data[ $source_field['field_label'] ];
+					$location_tooltip_field = $location_data[ $source_field['field_label'] ] ?? '';
 				} else {
 					$location_tooltip_field = get_post_meta( $location_id, 'field_' . $source_field['field_label'], true );
 				}

--- a/src/admin/class-locations.php
+++ b/src/admin/class-locations.php
@@ -427,7 +427,7 @@ class Locations {
 		if ( ! empty( $source_fields ) ) {
 			foreach ( $source_fields as $source_field ) {
 				// Include only fields that are set to show.
-				if ( ! isset( $source_field['field_show'] ) || 'on' !== $source_field['field_show'] ) {
+				if ( ! isset( $source_field['field_show'] ) || ! in_array( $source_field['field_show'], [ 1, 'on' ] ) ) {
 					continue;
 				}
 

--- a/src/rest_api/class-openkaarten-controller.php
+++ b/src/rest_api/class-openkaarten-controller.php
@@ -583,20 +583,33 @@ class Openkaarten_Controller extends \WP_REST_Posts_Controller {
 
 			// If the feature collection is a geojson, enrich the feature collection with the marker and tooltip information. But only for live datalayers.
 			if ( 'live' === $datalayer_url_type && 'geojson' === $output_format ) {
+				// Check if marker information or tooltip information is provided.
+				$markers = get_post_meta( $item->ID, 'markers', true );
+				$tooltip = get_post_meta( $item->ID, 'tooltip', true );
+
+				if ( empty( $markers ) && empty( $tooltip ) ) {
+					return $geom->out( $output_format );
+				}
+
 				// Try to parse the feature collection.
 				$geom_components = $geom->getComponents();
 
 				// If the feature collection is a feature, add the marker and tooltip information.
 				foreach ( $geom_components as $geom_component ) {
-					// Get marker information.
-					$item_marker = Locations::get_location_marker( $item->ID, false, $geom_component->getData() );
-					$geom_marker = [
-						'color' => $item_marker['color'],
-						'icon'  => Locations::get_location_marker_url( $item_marker['icon'] ),
-					];
+					if ( ! empty( $markers ) ) {
+						// Get marker information.
+						$item_marker = Locations::get_location_marker( $item->ID, false, $geom_component->getData() );
+						$geom_marker = [
+							'color' => $item_marker['color'],
+							'icon'  => Locations::get_location_marker_url( $item_marker['icon'] ),
+						];
 
-					$geom_component->setData( 'marker', $geom_marker );
-					$geom_component->setData( 'tooltip', Locations::get_location_tooltip( $item->ID, false, $geom_component->getData() ) );
+						$geom_component->setData( 'marker', $geom_marker );
+					}
+
+					if ( ! empty( $tooltip ) ) {
+						$geom_component->setData( 'tooltip', Locations::get_location_tooltip( $item->ID, false, $geom_component->getData() ) );
+					}
 				}
 
 				// Create a new geometry collection.

--- a/src/rest_api/class-openkaarten-controller.php
+++ b/src/rest_api/class-openkaarten-controller.php
@@ -581,7 +581,7 @@ class Openkaarten_Controller extends \WP_REST_Posts_Controller {
 		try {
 			$geom = geoPHP::load( $feature_collection );
 
-			// If the feature collection is a geojson, enrich the feature collection with the marker and tooltip information.
+			// If the feature collection is a geojson, enrich the feature collection with the marker and tooltip information. But only for live datalayers.
 			if ( 'live' === $datalayer_url_type && 'geojson' === $output_format ) {
 				// Try to parse the feature collection.
 				$geom_components = $geom->getComponents();


### PR DESCRIPTION
@richardkorthuis : Ik heb functionaliteit geschreven om bij live datalayers een tooltip en markerinformatie te kunnen invoeren. Dit was tot nu nog niet mogelijk. Dit heb ik gedaan door de source_fields te bepalen aan de hand van de componenten in het source bestand. 

Ook heb ik gewerkt aan functionaliteit om een datalayer URL aan te kunnen passen (wens van Yard). Als je dat doet, dan worden de title field mapping en de field mapping gereset en worden ook de locaties verwijderd en opnieuw geimporteerd (mits het een import url type datalayer is).